### PR TITLE
fix: fix heading for Spacer docs

### DIFF
--- a/pages/docs/components/spacer.mdx
+++ b/pages/docs/components/spacer.mdx
@@ -30,7 +30,7 @@ Provide empty space.
 `} />
 
 <Playground
-  title="Vertical"
+  title="Horizontal"
   scope={{ Spacer, Container, Col }}
   code={`
 <Container>


### PR DESCRIPTION
## PR Checklist

- [x] Fix linting errors
- [x] Label has been added


## Change information

Both examples have a heading that says "Vertical" even though the second one is clearly horizontal.

