### PR TITLE
fix(use-portal): don't remove shared element slot 

### DIFF
--- a/components/utils/use-portal.ts
+++ b/components/utils/use-portal.ts
@@ -21,13 +21,6 @@ const usePortal = (selectId: string = getId()): HTMLElement | null => {
       document.body.appendChild(el)
     }
     setElSnapshot(el)
-  
-    return () => {
-      const node = document.getElementById(id)
-      if (node) {
-        document.body.removeChild(node)
-      }
-    }
   }, [])
 
   return elSnapshot


### PR DESCRIPTION
## PR Checklist

- [x] Fix linting errors
- [x] Label has been added


## Change information

1. Multiple components may be using shared element slots, destroy a slot can affect other components.
2. Slot is empty and can be reused, no memory waste.

