### PR TITLE
fix: type of useInput

### DIFF
--- a/components/input/use-input.ts
+++ b/components/input/use-input.ts
@@ -10,7 +10,7 @@ const useInput = (
   reset: () => void
   bindings: {
     value: string
-    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+    onChange: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
   }
 } => {
   const [state, setState, currentRef] = useCurrentState<string>(initialValue)
@@ -22,7 +22,7 @@ const useInput = (
     reset: () => setState(initialValue),
     bindings: {
       value: state,
-      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         setState(event.target.value)
       },
     },


### PR DESCRIPTION
## PR Checklist

- [x] Fix linting errors
- [x] Label has been added


## Change information

Thanks for nice library!!

I fixed type of `useInput` 's arg.
I think we should be able use `useInput` also in `Textarea` component, and docs introduces use-case for using `useInput` in `Textarea` https://react.zeit-ui.co/en-us/components/textarea#with-useinput

But `bindings.onChange` which is returned by `useInput` can only handle **HTMLInputElement**, so TypeScript throw type errors when I use `useInput` in `Textarea` component.
I fixed it.
