### PR TITLE
fix: add parseint and scrollto polyfill to docs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -54,6 +54,18 @@ const nextConfig = {
       ]
     },
   },
+
+  webpack: function (cfg) {
+    const originalEntry = cfg.entry
+    cfg.entry = async () => {
+      const entries = await originalEntry()
+      if (entries['main.js'] && !entries['main.js'].includes('./scripts/polyfills.js')) {
+        entries['main.js'].unshift('./scripts/polyfills.js')
+      }
+      return entries
+    }
+    return cfg
+  },
 }
 
 module.exports = withMDX(nextConfig)

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-color": "^2.18.0",
     "react-dom": "^16.13.1",
     "react-live": "^2.2.2",
+    "smoothscroll-polyfill": "^0.4.4",
     "ts-jest": "^25.3.1",
     "typescript": "^3.8.3",
     "webpack": "^4.41.6",

--- a/scripts/polyfills.js
+++ b/scripts/polyfills.js
@@ -1,0 +1,11 @@
+/* eslint no-extend-native: 0 */
+
+// This file runs before React and Next.js core
+// This file is loaded for all browsers
+// Next.js includes a number of polyfills only for older browsers like IE11
+// Make sure you don't duplicate these in this file
+// https://github.com/zeit/next.js/blob/canary/packages/next-polyfill-nomodule/src/index.js
+
+import 'core-js/fn/number/parse-int'
+import smoothscroll from 'smoothscroll-polyfill'
+smoothscroll.polyfill()

--- a/yarn.lock
+++ b/yarn.lock
@@ -8533,6 +8533,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
+
 snake-case@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"


### PR DESCRIPTION
## PR Checklist

- [x] Fix linting errors
- [x] Label has been added


## Change information
 Fixed polyfill errors caused the docs to fail in internet explorer 11:
- Number.parseInt
- element.scrollTo

_**Number.praseInt** is used by `components/utils/color.js`_
_**element.scrollTo** is used by `tooltip, menu, sidebar and shared`_

resolved #229 #226 