### PR TITLE
fix(tabs): add role="button" to tab for a11y

### DIFF
--- a/components/tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs should render correctly 1`] = `
-"<div class=\\"tabs \\"><header class=\\"\\"><div class=\\"tab  \\">label1</div><div class=\\"tab  \\">label2</div></header><div class=\\"content\\"></div><style>
+"<div class=\\"tabs \\"><header class=\\"\\"><div class=\\"tab  \\" role=\\"button\\">label1</div><div class=\\"tab  \\" role=\\"button\\">label2</div></header><div class=\\"content\\"></div><style>
           .tabs {
             width: initial;
           }
@@ -76,7 +76,7 @@ exports[`Tabs should render correctly 1`] = `
 `;
 
 exports[`Tabs should work correctly with different styles 1`] = `
-"<div class=\\"tabs \\"><header class=\\"hide-divider\\"><div class=\\"tab  \\">label1</div></header><div class=\\"content\\"></div><style>
+"<div class=\\"tabs \\"><header class=\\"hide-divider\\"><div class=\\"tab  \\" role=\\"button\\">label1</div></header><div class=\\"content\\"></div><style>
           .tabs {
             width: initial;
           }

--- a/components/tabs/tabs.tsx
+++ b/components/tabs/tabs.tsx
@@ -76,6 +76,7 @@ const Tabs: React.FC<React.PropsWithChildren<TabsProps>> = ({
               className={`tab ${selfValue === item.value ? 'active' : ''} ${
                 item.disabled ? 'disabled' : ''
               }`}
+              role="button"
               key={item.value + index}
               onClick={() => clickHandler(item)}>
               {item.label}


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Label has been added

## Change information

Add `role="button"` to tabs, vercel style has the `role` attribute. This also [make vimium recognize the tab](https://github.com/philc/vimium/blob/bdf654aebe6f570f427c5f7bc9592cad86e642b5/content_scripts/link_hints.js#L912).

![image](https://user-images.githubusercontent.com/15090582/86351306-a35b3000-bc96-11ea-954e-460003e8a19c.png)

By the way, what does the "Label has been added" checkbox mean?
