### PR TITLE
style(popover-item): the whole item should be clickable when using with link

### DIFF
--- a/components/popover/popover-item.tsx
+++ b/components/popover/popover-item.tsx
@@ -39,7 +39,6 @@ const PopoverItem: React.FC<React.PropsWithChildren<PopoverItemProps>> = ({
             line-height: 1.25rem;
             text-align: left;
             transition: color 0.1s ease 0s, background-color 0.1s ease 0s;
-            width: max-content;
           }
 
           .item:hover {
@@ -48,6 +47,12 @@ const PopoverItem: React.FC<React.PropsWithChildren<PopoverItemProps>> = ({
 
           .item > :global(*) {
             margin: 0;
+          }
+
+          .item > :global(.link) {
+            width: 100%;
+            padding: 0.5rem ${theme.layout.gap};
+            margin: -0.5rem -${theme.layout.gap};
           }
 
           .item.line {


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

Before:
<img width="301" alt="CleanShot 2020-07-24 at 00 25 21@2x" src="https://user-images.githubusercontent.com/157338/88312018-36daca80-cd44-11ea-9c87-df0bfa45f3ec.png">

After:
<img width="287" alt="CleanShot 2020-07-24 at 00 26 30@2x" src="https://user-images.githubusercontent.com/157338/88312200-6d184a00-cd44-11ea-918b-47e983461884.png">

Vercel:
<img width="282" alt="CleanShot 2020-07-24 at 00 28 36@2x" src="https://user-images.githubusercontent.com/157338/88312981-78b84080-cd45-11ea-8fdb-408e8a34afc5.png">
