### PR TITLE
fix:add placement props to popover component

### DIFF
--- a/pages/en-us/components/popover.mdx
+++ b/pages/en-us/components/popover.mdx
@@ -23,7 +23,7 @@ The floating box popped by clicking or hovering.
     </div>
   )
   return (
-    <Popover content={content}>
+    <Popover content={content} placement="bottomStart">
       Menu
     </Popover>
   )
@@ -55,7 +55,7 @@ The floating box popped by clicking or hovering.
     </>
   )
   return (
-    <Popover content={content}>
+    <Popover content={content} placement="bottomStart">
       Menu
     </Popover>
   )
@@ -81,7 +81,8 @@ The floating box popped by clicking or hovering.
     </div>
   )
   return (
-    <Popover content={content} visible={visible}
+    <Popover content={content} placement="bottomStart"
+      visible={visible}
       onVisibleChange={changeHandler}>
       Menu
     </Popover>


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

Fix:#839
adding `placement="bottomStart"` to Popover component on the docs page so the popover-item stay inside the screen

before:

<img width="391" alt="Screen Shot 2023-10-30 at 4 12 35 PM" src="https://github.com/geist-org/geist-ui/assets/91102425/2ef61b0c-bae9-4e5a-bb2b-64a29b7c1599">

after:

<img width="392" alt="Screen Shot 2023-10-30 at 4 11 26 PM" src="https://github.com/geist-org/geist-ui/assets/91102425/fed08681-986e-4762-9cd4-6794f79db0aa">