### PR TITLE
Fix styles in Docs Tabs hideBorder demo

### DIFF
--- a/pages/en-us/components/tabs.mdx
+++ b/pages/en-us/components/tabs.mdx
@@ -57,7 +57,7 @@ The Tabs contain an additional Hooks, see subsection [useTabs](/en-us/hooks/use-
   title="Hide Border"
   scope={{ Tabs, Text }}
   code={`
-<Tabs initialValue="html" hideDivider hideBorder leftSpace={0}>
+<Tabs initialValue="html" hideDivider hideBorder leftSpace="6px">
   <Tabs.Item label="HTML" value="html">
     <Text mt={0}>HTML is the language that we use to structure the different parts of our content and define what their meaning or purpose is.</Text>
   </Tabs.Item>


### PR DESCRIPTION
- [Tabs Hide Border Docs Link](https://geist-ui.dev/en-us/components/tabs#hide-border)
<img width="247" alt="image" src="https://github.com/user-attachments/assets/d39a231a-c700-4777-9e59-8fc2d4b90086">

- The rounded corner on the left is hidden due to `leftSpace` being 0.
- The Effect after the fix:
![Kapture 2024-07-18 at 16 39 35](https://github.com/user-attachments/assets/03940645-2072-4e7e-a1a1-2cdf83763942)
